### PR TITLE
Support -SNAPSHOT artifacts

### DIFF
--- a/lib/nexus-artifact.coffee
+++ b/lib/nexus-artifact.coffee
@@ -30,5 +30,14 @@ module.exports = (grunt) -> class NexusArtifact
     "#{@buildUrlPath()}#{@buildArtifactUri()}"
 
   buildArtifactUri: () ->
+    grunt.log.writeln "@versionPattern #{@versionPattern}"
+    expandedVersion = @expandVersion @version
     @versionPattern.replace /%([ave])/g, ($0, $1) =>
-      { a: @name, v: @version, e: @ext}[$1]
+      { a: @name, v: expandedVersion, e: @ext}[$1]
+
+  expandVersion: (version) ->
+    if version.indexOf('-SNAPSHOT') > 0
+      now = new Date()
+      timestamp = '-' + now.toISOString().replace(/[-:]|\..*/g,'').replace('T','.')
+      version = version.replace('-SNAPSHOT', timestamp)
+    version


### PR DESCRIPTION
I've adapted the module to support -SNAPSHOT artifacts.

It might help others to add an example of how the repository can be selected and the application version can be modified based upon the current branch (GIT_BRANCH is set by Jenkins): 

```js
  if ('master' == process.env.GIT_BRANCH) {
    appConfig.nexus_repo = 'releases';
  } else {
    appConfig.nexus_repo = 'snapshots';
    appConfig.version += '-SNAPSHOT';
  }
```